### PR TITLE
Append to process buffer

### DIFF
--- a/prodigy.el
+++ b/prodigy.el
@@ -374,6 +374,7 @@ PROCESS is the service process that the OUTPUT is associated to."
     (let ((buffer (get-buffer-create (prodigy-buffer-name service))))
       (with-current-buffer buffer
         (let ((inhibit-read-only t))
+          (goto-char (point-max))
           (insert (ansi-color-apply output)))))))
 
 (defun prodigy-find-service (name)


### PR DESCRIPTION
The process output is inserted at point, which gets really messy if you scrolled through the output and it keeps outputting.

It would be great to save-excursion instead of following in case you did scroll through, but I wasn't sure how to achieve this without introducing some complexity...
