### PR TITLE
copy current service command line to the kill ring

### DIFF
--- a/prodigy.el
+++ b/prodigy.el
@@ -1142,10 +1142,10 @@ started."
 (defun prodigy-copy-cmd ()
   "Copy cmd at line."
   (interactive)
-  (let* ((service (car (prodigy-relevant-services)))
+  (let* ((service (prodigy-service-at-pos))
          (cmd (prodigy-service-command service))
          (args (prodigy-service-args service))
-         (cmd-str (concat cmd " " (mapconcat 'identity args " "))))
+         (cmd-str (concat cmd " " (s-join " " args))))
     (kill-new cmd-str)
     (message "%s" cmd-str)))
 


### PR DESCRIPTION
Sometimes it is very useful to copy paste service command line. Then you can paste it to terminal and modify the cmd.

I've implemented this feature and it is bound to C-w similarly to C-w in magit which copies the current commit sha1.
