### PR TITLE
Add support prodigy-callback in :init

### DIFF
--- a/prodigy.el
+++ b/prodigy.el
@@ -983,7 +983,7 @@ the process is put in failed status."
               (unless process
                 (setq process (apply 'start-process (append (list name nil command) args)))))))
       (-when-let (init (prodigy-service-init service))
-        (funcall init))
+        (prodigy-callback-with-plist init service))
       (-when-let (init-async (prodigy-service-init-async service))
         (let (callbacked)
           (funcall


### PR DESCRIPTION
Fixes #70

I'm not sure about this solution at all, even if it works for me.

The semantics of :init and :init-async should probably not diverge like this.
