### PR TITLE
Fix inheritence of url from tag

### DIFF
--- a/prodigy.el
+++ b/prodigy.el
@@ -755,7 +755,7 @@ The completion system used is determined by
 (defun prodigy-url (service)
   "Return SERVICE url."
   (or
-   (plist-get service :url)
+   (prodigy-service-url service)
    (-when-let (port (prodigy-service-port service))
      (format "http://localhost:%d" port))))
 

--- a/test/prodigy-test.el
+++ b/test/prodigy-test.el
@@ -46,6 +46,16 @@
    (stub prodigy-service-port)
    (should-not (prodigy-url (prodigy-test/make-service)))))
 
+(ert-deftest prodigy-url-test/inherit-from-tag ()
+  (let ((prodigy-tags '((:name foo :url "http://localhost:3000")))
+        (service '(:tags (foo))))
+    (should (equal (prodigy-url service) "http://localhost:3000"))))
+
+(ert-deftest prodigy-url-test/override-from-tag ()
+  (let ((prodigy-tags '((:name foo :url "http://localhost:3000")))
+        (service '(:tags (foo) :url "http://localhost:3001")))
+    (should (equal (prodigy-url service) "http://localhost:3001"))))
+
 
 ;;;; prodigy-browse
 


### PR DESCRIPTION
URL should be inherited from tags, but was previously not.