### PR TITLE
Default `prodigy-status-list` before `prodigy-set-status`

### DIFF
--- a/prodigy.el
+++ b/prodigy.el
@@ -642,6 +642,8 @@ has that property and return its value."
 
 If ID is nil, use id stopped, which is the default service
 status."
+  (unless prodigy-status-list
+    (prodigy-define-default-status-list))
   (unless id (setq id 'stopped))
   (-first
    (lambda (status)

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -93,7 +93,6 @@ ACTION and ARGS are json encoded and sent to the process."
      (setq prodigy-stop-tryouts 1)
      (setq prodigy-filters nil)
      (setq prodigy-view-truncate-by-default nil)
-     (prodigy-define-default-status-list)
      (with-mock ,@body)))
 
 (defun prodigy-test/delay (seconds callback)


### PR DESCRIPTION
When using `prodigy-set-status` is called, just default the `proidgy-status-list` if it is `nil`. Basically just a safety check when not going through the `prodigy` buffer.