### PR TITLE
Provide scoped test helper

### DIFF
--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -107,6 +107,6 @@ ACTION and ARGS are json encoded and sent to the process."
 (eval-when-compile
   (require 'cl))
 
-(provide 'test-helper)
+(provide 'prodigy-test-helper)
 
 ;;; test-helper.el ends here


### PR DESCRIPTION
Simply calling it test-helper conflicts with other packages. See https://github.com/rejeep/prodigy.el/issues/94 for more information.