### PR TITLE
Add support for :sudo service property

### DIFF
--- a/prodigy.el
+++ b/prodigy.el
@@ -162,6 +162,9 @@ The list is a property list with the following properties:
 `cwd'
   Run command with this as `default-directory'.
 
+`sudo'
+  Run command as `sudo'
+
 `port'
   Specify service port for use with open function.
 

--- a/prodigy.el
+++ b/prodigy.el
@@ -966,6 +966,7 @@ NAME, BUFFER, PROGRAM, and PROGRAM-ARGS are as in `start-process.'"
          (start-process-shell-command
           name buffer (concat "sudo " (mapconcat #'shell-quote-argument sudo-args " ")))))
     (process-send-string process pwd)
+    (clear-string pwd)
     (process-send-string process "\r")
     (process-send-eof process)
     process))

--- a/prodigy.el
+++ b/prodigy.el
@@ -957,6 +957,19 @@ Note that the return value is always a list."
 
 ;;;; Process handling
 
+(defun prodigy-start-sudo-process (name buffer program &rest program-args)
+  "Prompt the user for a password and start a process with sudo.
+NAME, BUFFER, PROGRAM, and PROGRAM-ARGS are as in `start-process.'"
+  (let* ((sudo-args (cons program program-args))
+         (pwd (read-passwd (concat "Sudo password for `" (mapconcat #'identity sudo-args " ") "': ")))
+         (process
+         (start-process-shell-command
+          name buffer (concat "sudo " (mapconcat #'shell-quote-argument sudo-args " ")))))
+    (process-send-string process pwd)
+    (process-send-string process "\r")
+    (process-send-eof process)
+    process))
+
 (defun prodigy-start-service (service &optional callback)
   "Start process associated with SERVICE unless already started.
 
@@ -974,6 +987,7 @@ the process is put in failed status."
                  (f-full cwd)
                default-directory))
            (name (plist-get service :name))
+           (sudo (plist-get service :sudo))
            (command (prodigy-service-command service))
            (args (prodigy-service-args service))
            (exec-path (append (prodigy-service-path service) exec-path))
@@ -983,7 +997,8 @@ the process is put in failed status."
            (create-process
             (lambda ()
               (unless process
-                (setq process (apply 'start-process (append (list name nil command) args)))))))
+                (setq process (apply (if sudo 'prodigy-start-sudo-process 'start-process)
+                                     (append (list name nil  command) args)))))))
       (-when-let (init (prodigy-service-init service))
         (funcall init))
       (-when-let (init-async (prodigy-service-init-async service))


### PR DESCRIPTION
I've taken a first stab at adding sudo (#29) support by calling the process through the shell. You can see the results here. This PR only includes support for the `:sudo` prop, not for `:sudo-user`, as you'd originally specified.

If you approve of the approach I'll add some unit tests to get this merged. 

------

**Todos**:
- [X] Implement `:sudo` functionality
- [X] Add unit test for sudo services
- [X] Update docstring for prodigy-services