### PR TITLE
adds `prodigy-clear-underlying-buffers`

### DIFF
--- a/prodigy.el
+++ b/prodigy.el
@@ -1181,6 +1181,20 @@ started."
   (prodigy-with-refresh
    (-each (prodigy-relevant-services) 'prodigy-start-service)))
 
+(defun prodigy-clear-underlying-buffer (service)
+  "Clear output buffer associated with SERVICE"
+  (-if-let (buffer (get-buffer (prodigy-buffer-name service)))
+      (progn
+        (with-current-buffer buffer
+          (prodigy-view-clear-buffer)))
+    (message "Nothing to clear for `'%s`'"
+             (plist-get service :name))))
+
+(defun prodigy-clear-underlying-buffers ()
+  "Clear service's underlying buffer at line or marked services."
+  (interactive)
+  (-each (prodigy-relevant-services) 'prodigy-clear-underlying-buffer))
+
 (defun prodigy-stop (&optional force)
   "Stop service at line or marked services.
 


### PR DESCRIPTION
## Context
Sometimes I want to clear the otuput of a couple of processes running without
having to enter each of the output buffers and call prodigy-view-clear-buffer.


### Description
This pull request adds prodigy-clear-underlying-buffers.

This pull request still misses some tests, but I would like to ask if you
would find this useful.

All best and thanks for your help.


## Status
IN-PROGRESS


## Todos
- [X] Implement prodigy-clear-underlying-buffers
- [ ] Add tests

