### PR TITLE
Add imenu support in the prodigy buffer

### DIFF
--- a/prodigy.el
+++ b/prodigy.el
@@ -1382,7 +1382,25 @@ The old service process is transfered to the new service."
   (hl-line-mode 1)
   (when (featurep 'discover)
     (prodigy-discover-initialize))
+  (setq imenu-prev-index-position-function
+        #'prodigy--imenu-prev-index-position-function)
+  (setq imenu-extract-index-name-function
+        #'prodigy--imenu-extract-index-name-function)
   (run-mode-hooks 'prodigy-mode-hook))
+
+(defun prodigy--imenu-prev-index-position-function ()
+  "Move point to previous line in prodigy buffer.
+This function is used as a value for
+`imenu-prev-index-position-function'."
+  (unless (bobp)
+    (forward-line -1)))
+
+(defun prodigy--imenu-extract-index-name-function ()
+  "Return imenu name for line at point.
+This function is used as a value for
+`imenu-extract-index-name-function'.  Point should be at the
+beginning of the line."
+  (elt (tabulated-list-get-entry) 1))
 
 ;;;###autoload
 (define-derived-mode prodigy-view-mode special-mode "Prodigy-view"


### PR DESCRIPTION
Emacs' major modes can facilitate navigation in their buffers by
supporting Imenu. In such major modes, launching Imenu (M-x imenu)
makes Emacs display a list of items (e.g., function definitions in a
code buffer). Selecting an item from this list moves point to this
item.