### PR TITLE
Do not run the mode hooks manually

### DIFF
--- a/prodigy.el
+++ b/prodigy.el
@@ -1404,8 +1404,7 @@ The old service process is transfered to the new service."
   (setq imenu-prev-index-position-function
         #'prodigy--imenu-prev-index-position-function)
   (setq imenu-extract-index-name-function
-        #'prodigy--imenu-extract-index-name-function)
-  (run-mode-hooks 'prodigy-mode-hook))
+        #'prodigy--imenu-extract-index-name-function))
 
 (defun prodigy--imenu-prev-index-position-function ()
   "Move point to previous line in prodigy buffer.


### PR DESCRIPTION
The macro `define-derived-mode` already runs the hook automatically.

See

```elisp
(defun my-prodigy-init ()
  (message "foo"))

(add-hook 'prodigy-mode-hook 'my-prodigy-init)
```

the message is printed twice