### PR TITLE
wip: Apply backspace to log output

### DIFF
--- a/prodigy.el
+++ b/prodigy.el
@@ -899,21 +899,10 @@ DIRECTION is either 'up or 'down."
       (goto-char (point-max))
       (insert (prodigy-process-output output))
       ;; (prodigy-apply-ansi-escapes (prodigy-process-output output) (current-buffer))
-      ;; (save-excursion
-      ;;   (goto-char current-position)
-      ;;   (while (re-search-forward "\\(\\)+" nil t)
-      ;;     (delete-char (* 2 (- (match-beginning 0) (match-end 0)))))
-      ;;   (goto-char current-position)
-      ;;   (while (re-search-forward (rx "[" (group (1+ digit)) (group (char ?A ?B ?K))) nil t)
-      ;;     (let ((arg (string-to-number (match-string 1)))
-      ;;           (command (match-string 2)))
-      ;;       (cond
-      ;;        ((equal command "A")
-      ;;         (forward-line (- arg)))
-      ;;        ((equal command "B")
-      ;;         (forward-line arg))
-      ;;        ((equal command "K")
-      ;;         (delete-region (point) (line-end-position)))))))
+      (save-excursion
+        (goto-char current-position)
+        (while (re-search-forward "\\(\\)+" nil t)
+          (delete-char (* 2 (- (match-beginning 0) (match-end 0))))))
       (unless at-buffer-end
         (goto-char current-position)))))
 

--- a/prodigy.el
+++ b/prodigy.el
@@ -869,6 +869,10 @@ DIRECTION is either 'up or 'down."
           (at-buffer-end (equal (point) (point-max))))
       (goto-char (point-max))
       (insert (prodigy-process-output output))
+      (save-excursion
+        (goto-char current-position)
+        (while (re-search-forward "\\(\\)+" nil t)
+          (delete-char (* 2 (- (match-beginning 0) (match-end 0))))))
       (unless at-buffer-end
         (goto-char current-position)))))
 


### PR DESCRIPTION
Tools like webpack print a lot of `^H` into the output to simulate the "update-in-place" effect in the terminal.  This litters the prodigy buffer with thousands of lines of crap.

I've added a bit of code to "interpret" the `^H` as a "delete one char back".  The implementation I don't quite like because:

1. It is not an output filter.  However with the current design it's impossible to design it as such because the backspaces might come chunked and so we can't only "filter on one chunk at a time" (the variable `output` in `prodigy-process-output`).
2. It is an ad-hoc implementation for one control-sequence.

Maybe we can introduce a new hook variable that would work directly on the log buffer instead of only on the chunks and start placing these functions there.

I've tried to make use of `term` which would be super cool but it is quite rigid in how its implemented and seems that hacking it to somehow be usable as a generic filter is quite impossible, so we might need to implement bits and pieces ourselves.

I'm opening this up for discussion/design decisions.