### PR TITLE
Make it possible to keep the process buffer if it is visible.

### DIFF
--- a/prodigy.el
+++ b/prodigy.el
@@ -498,7 +498,8 @@ SERVICE tag that has and return that."
 
 If SERVICE kill-process-buffer-on-stop exists, use that.  If not, find the first
 SERVICE tag that has and return that."
-  (prodigy-service-or-first-tag-with service :kill-process-buffer-on-stop))
+  (or (prodigy-service-or-first-tag-with service :kill-process-buffer-on-stop)
+      prodigy-kill-process-buffer-on-stop))
 
 (defun prodigy-service-path (service)
   "Return list of SERVICE path extended with all tags path."
@@ -618,14 +619,13 @@ All windows from all frames are considered."
 
 (defun prodigy-maybe-kill-process-buffer (service)
   "Kill SERVICE buffer if kill-process-buffer-on-stop is t."
-  (let* ((kill-process-buffer-on-stop (prodigy-service-kill-process-buffer-on-stop service))
-         (kill-buffer (or kill-process-buffer-on-stop prodigy-kill-process-buffer-on-stop)))
+  (let* ((kill-process-buffer (prodigy-service-kill-process-buffer-on-stop service)))
     (-when-let (buffer (get-buffer (prodigy-buffer-name service)))
       (cond
-       ((eq kill-buffer 'unless-visible)
+       ((eq kill-process-buffer 'unless-visible)
         (unless (prodigy-process-buffer-visible-p service)
           (kill-buffer buffer)))
-       ((eq kill-buffer t)
+       ((eq kill-process-buffer t)
         (kill-buffer buffer))))))
 
 (defun prodigy-service-started-p (service)

--- a/prodigy.el
+++ b/prodigy.el
@@ -90,7 +90,10 @@ An example is restarting a service."
 (defcustom prodigy-kill-process-buffer-on-stop nil
   "Will kill process buffer on stop if this is true."
   :group 'prodigy
-  :type 'boolean)
+  :type '(radio
+          (const :tag "Always kill buffer" t)
+          (const :tag "Kill buffer unless it is visible" unless-visible)
+          (const :tag "Never kill buffer" nil)))
 
 (defcustom prodigy-timer-interval 1
   "How often to check for process changes, in seconds."
@@ -211,6 +214,12 @@ The list is a property list with the following properties:
 
 `kill-process-buffer-on-stop'
   Kill associated process buffer when process stops.
+  Possible values are:
+   * t - always kill the buffer.
+   * `unless-visible' - kill the buffer unless it is visible in some
+     window in any frame.
+   * `never' - never kill the buffer.
+   * nil or not set - use the value of `prodigy-kill-process-buffer-on-stop'.
 
 `truncate-output'
  Truncates the process ouptut buffer.  If set to t, truncates to
@@ -598,12 +607,26 @@ the timeouts stop."
       (progn (pop-to-buffer buffer) (prodigy-view-mode))
     (message "Nothing to show for %s" (plist-get service :name))))
 
+(defun prodigy-process-buffer-visible-p (service)
+  "Return non-nil if process buffer for SERVICE is visible.
+
+All windows from all frames are considered."
+  (-when-let (buffer (get-buffer (prodigy-buffer-name service)))
+    (-any?
+     (lambda (window) (equal (window-buffer window) buffer))
+     (-mapcat 'window-list (frame-list)))))
+
 (defun prodigy-maybe-kill-process-buffer (service)
   "Kill SERVICE buffer if kill-process-buffer-on-stop is t."
-  (let ((kill-process-buffer-on-stop (prodigy-service-kill-process-buffer-on-stop service)))
-    (when (or kill-process-buffer-on-stop prodigy-kill-process-buffer-on-stop)
-      (-when-let (buffer (get-buffer (prodigy-buffer-name service)))
-        (kill-buffer buffer)))))
+  (let* ((kill-process-buffer-on-stop (prodigy-service-kill-process-buffer-on-stop service))
+         (kill-buffer (or kill-process-buffer-on-stop prodigy-kill-process-buffer-on-stop)))
+    (-when-let (buffer (get-buffer (prodigy-buffer-name service)))
+      (cond
+       ((eq kill-buffer 'unless-visible)
+        (unless (prodigy-process-buffer-visible-p service)
+          (kill-buffer buffer)))
+       ((eq kill-buffer t)
+        (kill-buffer buffer))))))
 
 (defun prodigy-service-started-p (service)
   "Return true if SERVICE is started, false otherwise."

--- a/test/prodigy-service-accessors-test.el
+++ b/test/prodigy-service-accessors-test.el
@@ -199,7 +199,10 @@
     (should (prodigy-service-kill-process-buffer-on-stop service-1))
     (should (prodigy-service-kill-process-buffer-on-stop service-2))
     (should (prodigy-service-kill-process-buffer-on-stop service-3))
-    (should-not (prodigy-service-kill-process-buffer-on-stop service-4))))
+    (should-not (prodigy-service-kill-process-buffer-on-stop service-4))
+    ;; when service variable is not set use the global option
+    (let ((prodigy-kill-process-buffer-on-stop t))
+      (should (prodigy-service-kill-process-buffer-on-stop service-4)))))
 
 
 ;;;; prodigy-service-path


### PR DESCRIPTION
Extend the setting of `prodigy-kill-process-buffer-on-stop` (and
related service option) with `'unless-visible` option to keep the
buffer alive if it is visible.

The workflow that inspired the change is something like this: have a
frame with all the log buffers visible... when we open the control
panel and do a restart everything stays in place and I don't have to
reopen all the buffers.

However, if some process runs in background and I stop it I would not
want to have hanging buffers around so they get cleaned automatically.

I'll try to add tests once we decide this is how we want to do this.