### PR TITLE
Make it possible to control service from its log buffer.

### DIFF
--- a/test/prodigy-view-test.el
+++ b/test/prodigy-view-test.el
@@ -182,6 +182,18 @@
   (with-service-buffer nil 'unless-visible
     (should-not (buffer-live-p buffer))))
 
+(ert-deftest prodigy-view-test/control/resolve-current-service ()
+  (with-service-buffer 'visible 'never
+    (should (equal (plist-get (prodigy-current-service) :name)
+                   (plist-get (prodigy-test/make-service) :name)))))
+
+(ert-deftest prodigy-view-test/control/resolve-relevant-services ()
+  (with-service-buffer 'visible 'never
+    (let ((services (prodigy-relevant-services)))
+      (should (= (length services) 1))
+      (should (equal (plist-get (car (prodigy-relevant-services)) :name)
+                     (plist-get (prodigy-test/make-service) :name))))))
+
 (provide 'prodigy-view-test)
 
 ;;; prodigy-view-test.el ends here


### PR DESCRIPTION
Fix #107.

We extend the `prodigy-relevant-services` to return the "active"
service if the selected window is the log window.  This makes it
seamlessly work with almost all existing functions.

We introduce `prodigy-current-service` and use it instead of
`prodigy-service-at-pos` when it makes sense (jump-to-magit/directory
and similar).

Finally, bind `C-c` prefix  in the view buffer to forward to
`prodigy-mode-map`---this way all the bindings will stay consistent
between the list and view buffers.

Gods bless you for having a sensible architecture in place :)

### TODO

- [x] can we come up with a better prefix? I would prefer `c` as in `control` but that is taken by `view-mode` and someone might depend on that.  But it's much faster and simpler to just have letters instead of chords.
- [ ] tests