### PR TITLE
Problem: copy command at line leaves environment variables out

### DIFF
--- a/Cask
+++ b/Cask
@@ -6,6 +6,7 @@
 (development
  (depends-on "f")
  (depends-on "ecukes")
+ (depends-on "shut-up")
  (depends-on "el-mock")
  (depends-on "ert-runner")
  (depends-on "ert-async"))

--- a/prodigy.el
+++ b/prodigy.el
@@ -1196,9 +1196,15 @@ started."
   "Copy cmd at line."
   (interactive)
   (let* ((service (prodigy-service-at-pos))
+         (envs (s-join " "
+                       (-map (lambda (env-var-value)
+                                 (s-join "=" env-var-value))
+                               (prodigy-service-env service))))
+         (envs-string (if (not (s-equals? envs ""))
+                          (concat "env " envs " ")))
          (cmd (prodigy-service-command service))
          (args (prodigy-service-args service))
-         (cmd-str (concat cmd " " (s-join " " args))))
+         (cmd-str (concat envs-string cmd " " (s-join " " args))))
     (kill-new cmd-str)
     (message "%s" cmd-str)))
 

--- a/test/prodigy-test.el
+++ b/test/prodigy-test.el
@@ -80,6 +80,25 @@
    (mock (browse-url "http://localhost:3000/foo"))
    (prodigy-browse)))
 
+
+;;;; prodigy-copy-cmd
+
+(ert-deftest prodigy-copy-cmd-test/multiple-env ()
+  (with-mock
+   (stub prodigy-service-at-pos => '(:command "stub-service"
+                                     :args ("--stub-arg")
+                                     :env (("STUB_ENV_A" "a")
+                                           ("STUB_ENV_B" "b"))))
+   (mock (kill-new "env STUB_ENV_A=a STUB_ENV_B=b stub-service --stub-arg"))
+   (shut-up (prodigy-copy-cmd))))
+
+(ert-deftest prodigy-copy-cmd-test/no-env ()
+  (with-mock
+   (stub prodigy-service-at-pos => '(:command "stub-service"
+                                     :args ("--stub-arg")))
+   (mock (kill-new "stub-service --stub-arg"))
+   (shut-up (prodigy-copy-cmd))))
+
 (provide 'prodigy-api)
 
 ;;; prodigy-api.el ends here


### PR DESCRIPTION
When I copy a command with `prodigy-copy-cmd`  I would like to get the environmet variables copied to the kill-ring to be able to paste the command directly in a terminal.

This PR adds environment variables to the yank command. Would this make sense to you?