### PR TITLE
custom prodigy columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,21 @@ interactive functions available from the main `M-x prodigy` buffer
 under the `c` prefix key.  For example, to restart the service
 associated with the view buffer, press `c r`.
 
+### Columns
+In the `*prodigy*` buffer, you will always see a table with the following columns.
+  - **Marked**: Services that you want to perform an action on.
+  - **Name**: Service name.
+  - **Status**: Service status.
+  - **Tags**: Service associated tags.
+
+Edit `prodigy-custom-list-columns` to add your own columns, e.g.
+```lisp
+(setq prodigy-custom-list-columns
+   (quote
+    ((:function my-function :format
+                ("My Column Name" 25 t)))))
+```
+
 ### Tags
 
 Services can have any number of tags. Tags do not have to be


### PR DESCRIPTION
## Context
Problem: Sometimes I need to checkout different branches for certain processes
running under prodigy. In that situation I would like to see which branches I
checked out.


### Description
This pull request adds a new column that could be activated via defcustom.


## Todos
- [x] Add `prodigy-list-columns` joining prodigy column functions and formats
- [x] Add `prodigy-branch-col` 
  - Shows current branch
  - If any file is modified show pencil symbol

Would you eventually interested in something like this?
At the moment looks as follows

<img width="366" alt="screen shot 2018-03-16 at 20 50 35" src="https://user-images.githubusercontent.com/6558089/37542002-efeb4a10-295c-11e8-8ee4-11fbc641b542.png">
