### PR TITLE
Make it possible to store a function in :url

### DIFF
--- a/prodigy.el
+++ b/prodigy.el
@@ -209,9 +209,10 @@ The list is a property list with the following properties:
   environment variable and second item is the value of the variable.
 
 `url'
-  Single url or list of urls to use for browsing.  If single url is
-  specified, use that.  If a list of urls are specified, ask for what
-  url to browse.
+  Single url or list of urls to use for browsing.  If single
+  url is a string, use that.  If single url is a function,
+  evaluate the function and use the result.  If a list of urls
+  is specified, ask for what url to browse.
 
 `kill-process-buffer-on-stop'
   Kill associated process buffer when process stops.
@@ -529,7 +530,10 @@ SERVICE tag that has and return that."
 
 If SERVICE url exists, use that.  If not, find the first SERVICE
 tag that has and return that."
-  (prodigy-service-or-first-tag-with service :url))
+  (let ((url (prodigy-service-or-first-tag-with service :url)))
+    (if (functionp url)
+        (prodigy-callback-with-plist url service)
+      url)))
 
 (defun prodigy-service-on-output (service)
   "Return SERVICE and its tags on-output functions as list.


### PR DESCRIPTION
This is useful when the default URL
  `(format "http://localhost:%d" port)`
or a plain string don't work. For example, the URL must contain the
PORT and a path
  `(format "http://localhost:%d/foo/bar" port)`

A simpler but less powerful solution would be to add a new `:url-path` property which could just be `"/foo/bar"` in the example above.